### PR TITLE
Expose all of header files

### DIFF
--- a/FLEX.podspec
+++ b/FLEX.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |spec|
        'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++11',
   }
   spec.compiler_flags   = "-Wno-unsupported-availability-guard", "-Wno-deprecated-declarations"
-  spec.public_header_files = [ "Classes/*.h", "Classes/Manager/*.h", "Classes/Toolbar/*.h",
+  spec.public_header_files = [ "Classes/**/*.h", "Classes/Manager/*.h", "Classes/Toolbar/*.h",
                                "Classes/Core/Controllers/*.h", "Classes/Core/Views/*.h",
                                "Classes/Core/Views/Cells/*.h", "Classes/Core/*.h", 
                                "Classes/Utility/Categories/*.h",


### PR DESCRIPTION
This change is required because FLEX has a header(`.h`) and .m files spread across multiple directories and the header files import each other, to be able find those headers we need to pass its directory to compiler invocation hence we need to expose all of these headers mentioned in podspec, then in our macro we pass them to copts.